### PR TITLE
Maintain the order of metric labels in adding to JMX ObjectName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         It provides an object name factory for Dropwizard that adds the support for metric labels.
         Labels are of great value for example on aggregating metrics by Prometheus.
     </description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <properties>
       <dropwizard.metrics-core.version>3.1.2</dropwizard.metrics-core.version>


### PR DESCRIPTION
Change the method of constructing JMX beans to put  the metric name as the first property in the JMX bean. This is required to produce the correct output by Prometheus JXM exporter.